### PR TITLE
Improve regex pattern for parsing ban entries

### DIFF
--- a/fail2ban-client/fail2ban-client.go
+++ b/fail2ban-client/fail2ban-client.go
@@ -250,7 +250,7 @@ func (f2bc *Fail2BanClient) GetBanned(jailName string) (*JailEntry, error) {
 			for index := 0; index < banListLen; index++ {
 				if listEnty, listEntyOk := banList.Get(index).(string); listEntyOk {
 					log.Tracef("GetBanned: Parsing ban entry: %s", listEnty)
-					re := regexp.MustCompile(`^(\d{1,3}(?:\.\d{1,3}){3}) \t(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) \+ (\d+) = (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})$`)
+					re := regexp.MustCompile(`^(\d{1,3}(?:\.\d{1,3}){3})[ \t]+(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) \+ (-?\d+) = (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})$`)
 
 					matches := re.FindStringSubmatch(listEnty)
 					if matches == nil {


### PR DESCRIPTION
Thank you for building this tool I really appreciate it!

While I was trying to fix some connection issues on my server I also looked at the container logs running this image and I noticed a lot of entries like this one:

> 2026/04/17 20:36:28.885895 fail2ban-client.go:257: [Error] GetBanned: Failed to parse ban entry: 111.22.33.4       2026-04-16 12:43:13 + -1 = 9999-12-31 23:59:59

These were coming from my ufw rule, but when I fetched the banned ips for another rule I got a similar looking entry:

> 1.2.3.4          2026-04-17 14:28:20 + 3600 = 2026-04-17 15:28:20

Both of these ban entries would not match the regex before the error position.
I updated the regex to allow for multiple spaces and/or tabs after the ip address and also allow for negative numbers in the duration.